### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -1,5 +1,8 @@
 name: HTML Proofer
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/zunalita/zunalita.github.io/security/code-scanning/1](https://github.com/zunalita/zunalita.github.io/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily reads repository contents and does not perform write operations, the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`htmlproofer`) to limit permissions for that job only. In this case, adding it at the root level is recommended for simplicity and consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
