### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/zunalita/zunalita.github.io/security/code-scanning/2](https://github.com/zunalita/zunalita.github.io/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow. Since the workflow needs to push changes to the repository, it requires `contents: write` permissions. All other permissions should be omitted or set to `none` to minimize access. The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
