### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/zunalita/zunalita.github.io/security/code-scanning/4](https://github.com/zunalita/zunalita.github.io/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions performed in the workflow (e.g., checking out code, committing changes, pushing to a branch, and creating pull requests), the following permissions are required:
- `contents: read` for reading repository contents.
- `pull-requests: write` for creating pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `format` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
